### PR TITLE
Refactor settings

### DIFF
--- a/proto/core/Contract.options
+++ b/proto/core/Contract.options
@@ -12,6 +12,7 @@ protocol.TransferAssetContract.to_address           max_size: 21, fixed_length: 
 protocol.VoteWitnessContract.owner_address          max_size: 21, fixed_length: true
 protocol.VoteWitnessContract.votes                  max_count: 5  # Assume 5 votes max
 protocol.VoteWitnessContract.Vote.vote_address      max_size: 21, fixed_length: true
+protocol.VoteWitnessContract.support                type: FT_IGNORE
 
 protocol.FreezeBalanceContract.owner_address        max_size: 21, fixed_length: true
 protocol.FreezeBalanceContract.receiver_address     max_size: 21, fixed_length: true

--- a/proto/core/Contract.pb.h
+++ b/proto/core/Contract.pb.h
@@ -208,7 +208,6 @@ typedef struct _protocol_VoteWitnessContract {
     pb_byte_t owner_address[21];
     pb_size_t votes_count;
     protocol_VoteWitnessContract_Vote votes[5];
-    bool support;
 } protocol_VoteWitnessContract;
 
 
@@ -224,7 +223,7 @@ typedef struct _protocol_VoteWitnessContract {
 #define protocol_TransferContract_init_default   {{0}, {0}, 0}
 #define protocol_TransferAssetContract_init_default {{0, {0}}, {0}, {0}, 0}
 #define protocol_VoteAssetContract_init_default  {{{NULL}, NULL}, {{NULL}, NULL}, 0, 0}
-#define protocol_VoteWitnessContract_init_default {{0}, 0, {protocol_VoteWitnessContract_Vote_init_default, protocol_VoteWitnessContract_Vote_init_default, protocol_VoteWitnessContract_Vote_init_default, protocol_VoteWitnessContract_Vote_init_default, protocol_VoteWitnessContract_Vote_init_default}, 0}
+#define protocol_VoteWitnessContract_init_default {{0}, 0, {protocol_VoteWitnessContract_Vote_init_default, protocol_VoteWitnessContract_Vote_init_default, protocol_VoteWitnessContract_Vote_init_default, protocol_VoteWitnessContract_Vote_init_default, protocol_VoteWitnessContract_Vote_init_default}}
 #define protocol_VoteWitnessContract_Vote_init_default {{0}, 0}
 #define protocol_WitnessCreateContract_init_default {{{NULL}, NULL}, {{NULL}, NULL}}
 #define protocol_WitnessUpdateContract_init_default {{{NULL}, NULL}, {{NULL}, NULL}}
@@ -252,7 +251,7 @@ typedef struct _protocol_VoteWitnessContract {
 #define protocol_TransferContract_init_zero      {{0}, {0}, 0}
 #define protocol_TransferAssetContract_init_zero {{0, {0}}, {0}, {0}, 0}
 #define protocol_VoteAssetContract_init_zero     {{{NULL}, NULL}, {{NULL}, NULL}, 0, 0}
-#define protocol_VoteWitnessContract_init_zero   {{0}, 0, {protocol_VoteWitnessContract_Vote_init_zero, protocol_VoteWitnessContract_Vote_init_zero, protocol_VoteWitnessContract_Vote_init_zero, protocol_VoteWitnessContract_Vote_init_zero, protocol_VoteWitnessContract_Vote_init_zero}, 0}
+#define protocol_VoteWitnessContract_init_zero   {{0}, 0, {protocol_VoteWitnessContract_Vote_init_zero, protocol_VoteWitnessContract_Vote_init_zero, protocol_VoteWitnessContract_Vote_init_zero, protocol_VoteWitnessContract_Vote_init_zero, protocol_VoteWitnessContract_Vote_init_zero}}
 #define protocol_VoteWitnessContract_Vote_init_zero {{0}, 0}
 #define protocol_WitnessCreateContract_init_zero {{{NULL}, NULL}, {{NULL}, NULL}}
 #define protocol_WitnessUpdateContract_init_zero {{{NULL}, NULL}, {{NULL}, NULL}}
@@ -374,7 +373,6 @@ typedef struct _protocol_VoteWitnessContract {
 #define protocol_ProposalCreateContract_parameters_tag 2
 #define protocol_VoteWitnessContract_owner_address_tag 1
 #define protocol_VoteWitnessContract_votes_tag   2
-#define protocol_VoteWitnessContract_support_tag 3
 
 /* Struct field encoding specification for nanopb */
 #define protocol_AccountCreateContract_FIELDLIST(X, a) \
@@ -415,8 +413,7 @@ X(a, STATIC,   SINGULAR, INT32,    count,             5)
 
 #define protocol_VoteWitnessContract_FIELDLIST(X, a) \
 X(a, STATIC,   SINGULAR, FIXED_LENGTH_BYTES, owner_address,     1) \
-X(a, STATIC,   REPEATED, MESSAGE,  votes,             2) \
-X(a, STATIC,   SINGULAR, BOOL,     support,           3)
+X(a, STATIC,   REPEATED, MESSAGE,  votes,             2)
 #define protocol_VoteWitnessContract_CALLBACK NULL
 #define protocol_VoteWitnessContract_DEFAULT NULL
 #define protocol_VoteWitnessContract_votes_MSGTYPE protocol_VoteWitnessContract_Vote
@@ -655,7 +652,7 @@ extern const pb_msgdesc_t protocol_AccountPermissionUpdateContract_msg;
 #define protocol_TransferContract_size           57
 #define protocol_TransferAssetContract_size      75
 /* protocol_VoteAssetContract_size depends on runtime parameters */
-#define protocol_VoteWitnessContract_size        205
+#define protocol_VoteWitnessContract_size        203
 #define protocol_VoteWitnessContract_Vote_size   34
 /* protocol_WitnessCreateContract_size depends on runtime parameters */
 /* protocol_WitnessUpdateContract_size depends on runtime parameters */

--- a/proto/core/Tron.options
+++ b/proto/core/Tron.options
@@ -1,4 +1,11 @@
 protocol.Transaction.raw.contract           max_count: 1
+protocol.Transaction.raw.ref_block_bytes    type: FT_IGNORE
+protocol.Transaction.raw.ref_block_num      type: FT_IGNORE
+protocol.Transaction.raw.ref_block_hash     type: FT_IGNORE
+protocol.Transaction.raw.expiration         type: FT_IGNORE
+protocol.Transaction.raw.auths              type: FT_IGNORE
+protocol.Transaction.raw.scripts            type: FT_IGNORE
+protocol.Transaction.raw.timestamp          type: FT_IGNORE
 
 protocol.Key.address                        max_size: 21, fixed_length: true
 

--- a/proto/core/Tron.pb.h
+++ b/proto/core/Tron.pb.h
@@ -146,16 +146,9 @@ typedef struct _protocol_Permission {
 } protocol_Permission;
 
 typedef struct _protocol_Transaction_raw {
-    pb_callback_t ref_block_bytes;
-    int64_t ref_block_num;
-    pb_callback_t ref_block_hash;
-    int64_t expiration;
-    pb_callback_t auths;
     pb_callback_t data;
     pb_size_t contract_count;
     protocol_Transaction_Contract contract[1];
-    pb_callback_t scripts;
-    int64_t timestamp;
     int64_t fee_limit;
 } protocol_Transaction_raw;
 
@@ -196,7 +189,7 @@ typedef struct _protocol_Transaction {
 #define protocol_Transaction_init_default        {false, protocol_Transaction_raw_init_default, {{NULL}, NULL}, {{NULL}, NULL}}
 #define protocol_Transaction_Contract_init_default {_protocol_Transaction_Contract_ContractType_MIN, false, google_protobuf_Any_init_default, {{NULL}, NULL}, {{NULL}, NULL}, 0}
 #define protocol_Transaction_Result_init_default {0, _protocol_Transaction_Result_code_MIN, _protocol_Transaction_Result_contractResult_MIN, {{NULL}, NULL}, 0, 0, 0, 0, 0, 0}
-#define protocol_Transaction_raw_init_default    {{{NULL}, NULL}, 0, {{NULL}, NULL}, 0, {{NULL}, NULL}, {{NULL}, NULL}, 0, {protocol_Transaction_Contract_init_default}, {{NULL}, NULL}, 0, 0}
+#define protocol_Transaction_raw_init_default    {{{NULL}, NULL}, 0, {protocol_Transaction_Contract_init_default}, 0}
 #define protocol_Key_init_default                {{0}, 0}
 #define protocol_Permission_init_default         {_protocol_Permission_PermissionType_MIN, 0, {{NULL}, NULL}, 0, 0, {0}, 0, {protocol_Key_init_default, protocol_Key_init_default, protocol_Key_init_default}}
 #define protocol_Exchange_init_zero              {0, {{NULL}, NULL}, 0, {{NULL}, NULL}, 0, {{NULL}, NULL}, 0}
@@ -205,7 +198,7 @@ typedef struct _protocol_Transaction {
 #define protocol_Transaction_init_zero           {false, protocol_Transaction_raw_init_zero, {{NULL}, NULL}, {{NULL}, NULL}}
 #define protocol_Transaction_Contract_init_zero  {_protocol_Transaction_Contract_ContractType_MIN, false, google_protobuf_Any_init_zero, {{NULL}, NULL}, {{NULL}, NULL}, 0}
 #define protocol_Transaction_Result_init_zero    {0, _protocol_Transaction_Result_code_MIN, _protocol_Transaction_Result_contractResult_MIN, {{NULL}, NULL}, 0, 0, 0, 0, 0, 0}
-#define protocol_Transaction_raw_init_zero       {{{NULL}, NULL}, 0, {{NULL}, NULL}, 0, {{NULL}, NULL}, {{NULL}, NULL}, 0, {protocol_Transaction_Contract_init_zero}, {{NULL}, NULL}, 0, 0}
+#define protocol_Transaction_raw_init_zero       {{{NULL}, NULL}, 0, {protocol_Transaction_Contract_init_zero}, 0}
 #define protocol_Key_init_zero                   {{0}, 0}
 #define protocol_Permission_init_zero            {_protocol_Permission_PermissionType_MIN, 0, {{NULL}, NULL}, 0, 0, {0}, 0, {protocol_Key_init_zero, protocol_Key_init_zero, protocol_Key_init_zero}}
 
@@ -245,15 +238,8 @@ typedef struct _protocol_Transaction {
 #define protocol_Permission_parent_id_tag        5
 #define protocol_Permission_operations_tag       6
 #define protocol_Permission_keys_tag             7
-#define protocol_Transaction_raw_ref_block_bytes_tag 1
-#define protocol_Transaction_raw_ref_block_num_tag 3
-#define protocol_Transaction_raw_ref_block_hash_tag 4
-#define protocol_Transaction_raw_expiration_tag  8
-#define protocol_Transaction_raw_auths_tag       9
 #define protocol_Transaction_raw_data_tag        10
 #define protocol_Transaction_raw_contract_tag    11
-#define protocol_Transaction_raw_scripts_tag     12
-#define protocol_Transaction_raw_timestamp_tag   14
 #define protocol_Transaction_raw_fee_limit_tag   18
 #define protocol_Transaction_raw_data_tag        1
 #define protocol_Transaction_signature_tag       2
@@ -318,19 +304,11 @@ X(a, STATIC,   SINGULAR, INT64,    exchange_id,      21)
 #define protocol_Transaction_Result_DEFAULT NULL
 
 #define protocol_Transaction_raw_FIELDLIST(X, a) \
-X(a, CALLBACK, SINGULAR, BYTES,    ref_block_bytes,   1) \
-X(a, STATIC,   SINGULAR, INT64,    ref_block_num,     3) \
-X(a, CALLBACK, SINGULAR, BYTES,    ref_block_hash,    4) \
-X(a, STATIC,   SINGULAR, INT64,    expiration,        8) \
-X(a, CALLBACK, REPEATED, MESSAGE,  auths,             9) \
 X(a, CALLBACK, SINGULAR, BYTES,    data,             10) \
 X(a, STATIC,   REPEATED, MESSAGE,  contract,         11) \
-X(a, CALLBACK, SINGULAR, BYTES,    scripts,          12) \
-X(a, STATIC,   SINGULAR, INT64,    timestamp,        14) \
 X(a, STATIC,   SINGULAR, INT64,    fee_limit,        18)
 #define protocol_Transaction_raw_CALLBACK pb_default_field_callback
 #define protocol_Transaction_raw_DEFAULT NULL
-#define protocol_Transaction_raw_auths_MSGTYPE protocol_authority
 #define protocol_Transaction_raw_contract_MSGTYPE protocol_Transaction_Contract
 
 #define protocol_Key_FIELDLIST(X, a) \

--- a/src/parse.c
+++ b/src/parse.c
@@ -717,7 +717,7 @@ parserStatus_e processTx(uint8_t *buffer, uint32_t length,
     return USTREAM_FAULT;
   }
 
-  if (!dataAllowed && content->dataBytes != 0) {
+  if (!HAS_SETTING(S_DATA_ALLOWED) && content->dataBytes != 0) {
     THROW(0x6a80);
   }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -1,6 +1,7 @@
 #include "os.h"
 #include "cx.h"
 #include <stdbool.h>
+#include "core/Contract.pb.h"
 
 #ifndef PARSE_H
 #define PARSE_H
@@ -21,8 +22,6 @@
 #define MAX_RAW_SIGNATURE 65
 #define MAX_TOKEN_LENGTH 67
 
-#include "../proto/core/Contract.pb.h"
-
 typedef union {
   protocol_TransferContract transfer_contract;
   protocol_TransferAssetContract transfer_asset_contract;
@@ -38,8 +37,8 @@ typedef union {
   protocol_ProposalDeleteContract proposal_delete_contract;
   protocol_WithdrawBalanceContract withdraw_balance_contract;
   protocol_FreezeBalanceContract freeze_balance_contract;
-  protocol_UnfreezeBalanceContract  unfreeze_balance_contract;
-  protocol_AccountPermissionUpdateContract  account_permission_update_contract;
+  protocol_UnfreezeBalanceContract unfreeze_balance_contract;
+  protocol_AccountPermissionUpdateContract account_permission_update_contract;
 } contract_t;
 
 extern contract_t msg;

--- a/src/settings.h
+++ b/src/settings.h
@@ -3,21 +3,32 @@
 
 #include <stdint.h>
 
-extern volatile uint8_t dataAllowed;
-extern volatile uint8_t customContract;
-extern volatile uint8_t truncateAddress;
-extern volatile uint8_t signByHash;
+typedef uint8_t internal_storage_t;
 
-typedef struct internalStorage_t {
-  uint8_t dataAllowed;
-  uint8_t customContract;
-  uint8_t truncateAddress;
-  uint8_t signByHash;
-  uint8_t initialized;
-} internalStorage_t;
+#define N_settings (*(volatile internal_storage_t *)PIC(&N_storage_real))
 
-#define N_storage (*(volatile internalStorage_t *)PIC(&N_storage_real))
+// the settings, stored in NVRAM. Initializer is ignored by ledger.
+extern const internal_storage_t N_storage_real;
 
-extern const internalStorage_t N_storage_real;
+// flip a bit k = 0 to 7 for u8
+#define _FLIP_BIT(n, k)  (((n) ^ (1 << (k))))
+
+// toggle a setting item
+#define SETTING_TOGGLE(_set) do {\
+    internal_storage_t _temp_settings = _FLIP_BIT(N_settings, _set); \
+    nvm_write((void*)&N_settings, (void*)&_temp_settings, sizeof(internal_storage_t)); \
+  } while(0)
+
+// check a setting item
+#define HAS_SETTING(k)  ((N_settings & (1 << (k))) >> (k))
+
+
+#define S_DATA_ALLOWED     0
+#define S_CUSTOM_CONTRACT  1
+#define S_TRUNCATE_ADDRESS 2
+#define S_SIGN_BY_HASH     3
+
+#define S_INITIALIZED      7
+
 
 #endif


### PR DESCRIPTION
- ignore some unused fields in nanopb to save memory
- refactor settings, use bit fields instead of byte fields